### PR TITLE
BW Monitoring Data Cleanup Scripts

### DIFF
--- a/BW_MonitoringData_Cleanup_Script/README.md
+++ b/BW_MonitoringData_Cleanup_Script/README.md
@@ -1,0 +1,20 @@
+# BW Monitoring Data Cleanup Scripts
+
+This folder is subject to the clean up the BW monitoring data from the database.
+
+## Available DataBase Scripts
+
+* cleanupDB_MSSql_script.sql
+* cleanupDB_MYSql_script.sql
+* cleanupDB_Oracle_script.sql
+* cleanupDB_Postgres_script.sql
+
+## Steps to clean up the data between the given timestamp
+
+1) Open the script file.
+2) Update the "low_timestamp" and "high_timestamp" in the file.
+3) Run the script file.
+
+## Troubleshoot
+
+In case any error occurs Check the text cases(Lower case, Upper case).

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_MSSql_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_MSSql_script.sql
@@ -1,0 +1,29 @@
+--
+-- Cleanup the data between the given timestamp.
+-- Provide low_timestamp and high_timestamp value.
+-- (e.g. SET @high_timestamp = 1578640730179).
+--
+DECLARE @low_timestamp BIGINT
+SET @low_timestamp = 0
+
+DECLARE @high_timestamp BIGINT
+SET @high_timestamp = 1578641000000
+
+--
+-- Delete data for table activityloggingstats
+--
+DELETE FROM activityloggingstats
+WHERE timestmp BETWEEN @low_timestamp AND @high_timestamp;
+
+--
+-- Delete data for table processinstanceloggingstats
+--
+DELETE FROM processinstanceloggingstats
+WHERE timestmp BETWEEN @low_timestamp AND @high_timestamp;
+
+--
+-- Delete data for table transitionloggingstats
+--
+DELETE FROM transitionloggingstats
+WHERE timestmp BETWEEN @low_timestamp AND @high_timestamp;
+

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_MYSql_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_MYSql_script.sql
@@ -1,0 +1,32 @@
+--
+-- Cleanup the data between the given timestamp.
+-- Provide low_timestamp and high_timestamp value.
+-- (e.g. @low_timestamp= 1578563669021;).
+--
+
+SET @low_timestamp= 1578563669021;
+SET @high_timestamp = 1578563679090;
+SET SQL_SAFE_UPDATES = 0;
+
+--
+-- Delete data for table ActivityLoggingStats
+--
+DELETE FROM ActivityLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
+
+--
+-- Delete data for table ProcessInstanceLoggingStats
+--
+DELETE FROM ProcessInstanceLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
+
+--
+-- Delete data for table TransitionLoggingStats
+--
+DELETE FROM TransitionLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
+
+SET SQL_SAFE_UPDATES = 1;

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Oracle_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Oracle_script.sql
@@ -1,0 +1,33 @@
+--
+-- Cleanup the data between the given timestamp.
+-- Provide low_timestamp and high_timestamp value.
+--
+DEFINE low_timestamp=1586331221384;
+DEFINE high_timestamp=1586331221770;
+
+--
+-- Delete data for table activityloggingstats
+--
+DELETE FROM "ACTIVITYLOGGINGSTATS"
+WHERE "TIMESTMP" BETWEEN '&&low_timestamp' AND '&&high_timestamp';
+
+COMMIT;
+--
+-- Delete data for table processinstanceloggingstats
+--
+DELETE FROM "PROCESSINSTANCELOGGINGSTATS"
+WHERE "TIMESTMP" BETWEEN '&low_timestamp' AND '&high_timestamp';
+
+COMMIT;
+--
+-- Delete data for table transitionloggingstats
+--
+DELETE FROM "TRANSITIONLOGGINGSTATS"
+WHERE "TIMESTMP" BETWEEN '&low_timestamp' AND '&high_timestamp';
+
+COMMIT;
+
+UNDEFINE low_timestamp;
+UNDEFINE high_timestamp;
+
+

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Postgres_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Postgres_script.sql
@@ -1,0 +1,15 @@
+--
+-- Delete data for table ActivityLoggingStats
+--
+DELETE FROM activityloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table ProcessInstanceLoggingStats
+--
+DELETE FROM processinstanceloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table TransitionLoggingStats
+--
+DELETE FROM transitionloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+


### PR DESCRIPTION
**BW Monitoring Data Cleanup Scripts (AMBW-39312)**

Database scripts are provided under **bw-samples/BW_MonitoringData_Cleanup_Script** to clean up the BW monitoring data.
The script will clean up the data from the following table on the bases of timestamp.

1) activityloggingstats
2) processinstanceloggingstats
3) transitionloggingstats

Database Script Details:
1) MS SQL
File **cleanupDB_mssql_script.sql** place under bw-samples/BW_MonitoringData_Cleanup_Script

2) MY SQL
File **cleanupDB_mysql_script.sql** place under bw-samples/BW_MonitoringData_Cleanup_Script

3) POSTGRES
File **cleanupDB_Postgres_script.sql** place under bw-samples/BW_MonitoringData_Cleanup_Script

4) ORACLE
File **cleanupDB_Oracle_script.sql** place under bw-samples/BW_MonitoringData_Cleanup_Script

Testcase:
1) Tested with MSSQL, MYSQL, ORACLE, and POSTGRES database.
