### PR TITLE
BW Monitoring Data Cleanup Scripts (AMBW-40240)

### DIFF
--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Db2_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Db2_script.sql
@@ -1,15 +1,29 @@
 --
+-- Cleanup the data between the given timestamp.
+-- Provide low_timestamp and high_timestamp value at line number 15,22,and 29.
+-- (e.g.: DELETE FROM ActivityLoggingStats 
+--        WHERE timestmp 
+--        BETWEEN 1278563669021 AND 1578563669021;
+--  ).
+--
+
+--
 -- Delete data for table ActivityLoggingStats
 --
-DELETE FROM activityloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+DELETE FROM ActivityLoggingStats 
+WHERE timestmp 
+BETWEEN 0 AND 0;
 
 --
 -- Delete data for table ProcessInstanceLoggingStats
 --
-DELETE FROM processinstanceloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+DELETE FROM ProcessInstanceLoggingStats 
+WHERE timestmp 
+BETWEEN 0 AND 0;
 
 --
 -- Delete data for table TransitionLoggingStats
 --
-DELETE FROM transitionloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
-
+DELETE FROM TransitionLoggingStats 
+WHERE timestmp 
+BETWEEN 0 and 0;

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Db2_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Db2_script.sql
@@ -1,0 +1,15 @@
+--
+-- Delete data for table ActivityLoggingStats
+--
+DELETE FROM activityloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table ProcessInstanceLoggingStats
+--
+DELETE FROM processinstanceloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table TransitionLoggingStats
+--
+DELETE FROM transitionloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Mariadb_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Mariadb_script.sql
@@ -1,15 +1,32 @@
 --
+-- Cleanup the data between the given timestamp.
+-- Provide low_timestamp and high_timestamp value.
+-- (e.g. @low_timestamp= 1578563669021;).
+--
+
+SET @low_timestamp= 1578563669021;
+SET @high_timestamp = 1578563679090;
+SET SQL_SAFE_UPDATES = 0;
+
+--
 -- Delete data for table ActivityLoggingStats
 --
-DELETE FROM activityloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+DELETE FROM ActivityLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
 
 --
 -- Delete data for table ProcessInstanceLoggingStats
 --
-DELETE FROM processinstanceloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+DELETE FROM ProcessInstanceLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
 
 --
 -- Delete data for table TransitionLoggingStats
 --
-DELETE FROM transitionloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+DELETE FROM TransitionLoggingStats 
+WHERE timestmp 
+BETWEEN @low_timestamp AND @high_timestamp;
 
+SET SQL_SAFE_UPDATES = 1;

--- a/BW_MonitoringData_Cleanup_Script/cleanupDB_Mariadb_script.sql
+++ b/BW_MonitoringData_Cleanup_Script/cleanupDB_Mariadb_script.sql
@@ -1,0 +1,15 @@
+--
+-- Delete data for table ActivityLoggingStats
+--
+DELETE FROM activityloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table ProcessInstanceLoggingStats
+--
+DELETE FROM processinstanceloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+
+--
+-- Delete data for table TransitionLoggingStats
+--
+DELETE FROM transitionloggingstats WHERE timestmp BETWEEN 1578561456693 AND 1578562521690;
+


### PR DESCRIPTION
Database scripts are provided under **bw-samples/BW_MonitoringData_Cleanup_Script** to clean up the BW monitoring data.
The script will clean up the data from the following table on the bases of timestamp.

activityloggingstats
processinstanceloggingstats
transitionloggingstats
Database Script Details:

**DB2**
File cleanupDB_Db2_script.sql place under bw-samples/BW_MonitoringData_Cleanup_Script

**MariaDB**
File cleanupDB_Mariadb_script.sql place under bw-samples/BW_MonitoringData_Cleanup_Script

**Testcase:**
Tested with DB2 and Mariadb database.